### PR TITLE
trigger build workflow on pull request events

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -2,6 +2,7 @@ name: build
 on:
   workflow_dispatch:
   push:
+  pull_request:
 
 jobs:
   build-juicefs-libjfs:
@@ -9,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-latest]
-    
+
     steps:
       - name: Checkout Github Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
So we can make sure the contributed code doesn't break our project.